### PR TITLE
Make sure convert functions have proper parameters for their request

### DIFF
--- a/generation/salt/micro_tile.go
+++ b/generation/salt/micro_tile.go
@@ -113,9 +113,15 @@ func (m *MicroTile) getTileConfig() (map[string]interface{}, error) {
 }
 
 func (m *MicroTile) convertTile(coord *binning.TileCoord, input []byte) ([]byte, error) {
+	// Make sure our parameters are in sync with the current tile
+	err := m.parseMicroParams(*m.parameters)
+	if nil != err {
+		return nil, err
+	}
+
 	var rawHits []map[string]interface{}
-	err := json.Unmarshal(input, &rawHits)
-	if err != nil {
+	err = json.Unmarshal(input, &rawHits)
+	if nil != err {
 		return nil, err
 	}
 

--- a/generation/salt/tile.go
+++ b/generation/salt/tile.go
@@ -182,38 +182,36 @@ func (t *TileData) CreateTiles(requests []*batch.TileRequest) {
 	for _, request := range consolidatedRequests {
 		Infof("Request for %d tiles for dataset %s of type %s", len(request.tiles), request.dataset, t.tileType)
 		// Make sure relevant parameters are available to conversion functions
-		t.Parse(request.params)
-		// Create our consolidated configuration
-		fullConfig := make(map[string]interface{})
-		fullConfig["tile"] = request.tileConfig
-		fullConfig["query"] = request.query
-		fullConfig["dataset"] = datasets[request.dataset]
-		// Put in all our tile requests, recording our response channel for each as we go
-		responseChannels := make(map[string]chan batch.TileResponse)
-		tileSpecs := make([]interface{}, 0)
-		for _, tileReq := range request.tiles {
-			c := tileReq.coord
-			tileSpec := make(map[string]interface{})
-			tileSpec["level"] = int(c.Z)
-			tileSpec["x"] = int(c.X)
-			tileSpec["y"] = int(c.Y)
-			tileSpecs = append(tileSpecs, tileSpec)
-			responseChannels[coordToString(int(c.Z), int(c.X), int(c.Y))] = tileReq.sendTo
-		}
-		fullConfig["tile-specs"] = tileSpecs
-
-		// Marshal the consolidated request into a string
-		requestBytes, err := json.Marshal(fullConfig)
-		if err != nil {
-			for _, channel := range responseChannels {
-				channel <- batch.TileResponse{
+		err = t.Parse(request.params)
+		if nil != err {
+			for _, tileReq := range request.tiles {
+				tileReq.sendTo <- batch.TileResponse{
 					Tile: nil,
 					Err:  err,
 				}
 			}
 		} else {
-			// Send the marshalled request to Salt, and await a response
-			result, err := connection.QueryTiles(requestBytes)
+			// Create our consolidated configuration
+			fullConfig := make(map[string]interface{})
+			fullConfig["tile"] = request.tileConfig
+			fullConfig["query"] = request.query
+			fullConfig["dataset"] = datasets[request.dataset]
+			// Put in all our tile requests, recording our response channel for each as we go
+			responseChannels := make(map[string]chan batch.TileResponse)
+			tileSpecs := make([]interface{}, 0)
+			for _, tileReq := range request.tiles {
+				c := tileReq.coord
+				tileSpec := make(map[string]interface{})
+				tileSpec["level"] = int(c.Z)
+				tileSpec["x"] = int(c.X)
+				tileSpec["y"] = int(c.Y)
+				tileSpecs = append(tileSpecs, tileSpec)
+				responseChannels[coordToString(int(c.Z), int(c.X), int(c.Y))] = tileReq.sendTo
+			}
+			fullConfig["tile-specs"] = tileSpecs
+
+			// Marshal the consolidated request into a string
+			requestBytes, err := json.Marshal(fullConfig)
 			if err != nil {
 				for _, channel := range responseChannels {
 					channel <- batch.TileResponse{
@@ -222,25 +220,36 @@ func (t *TileData) CreateTiles(requests []*batch.TileRequest) {
 					}
 				}
 			} else {
-				// Unpack the results
-				tiles := unpackTiles(result)
-				for key, channel := range responseChannels {
-					tile, ok := tiles[key]
-					if ok {
-						Debugf("Found tile for key %s[%s] of length %d", key, t.tileType, len(tile.data))
-						converted, err := t.convert(tile.coord, tile.data)
-						Debugf("Converted tile for key %s[%s] had length %d", key, t.tileType, len(converted))
+				// Send the marshalled request to Salt, and await a response
+				result, err := connection.QueryTiles(requestBytes)
+				if err != nil {
+					for _, channel := range responseChannels {
 						channel <- batch.TileResponse{
-							Tile: converted,
+							Tile: nil,
 							Err:  err,
 						}
-					} else {
-						// No tile, but no error either
-						Debugf("No tile found for key %s", key)
-						defaultTile, err := t.buildDefault()
-						channel <- batch.TileResponse{
-							Tile: defaultTile,
-							Err:  err,
+					}
+				} else {
+					// Unpack the results
+					tiles := unpackTiles(result)
+					for key, channel := range responseChannels {
+						tile, ok := tiles[key]
+						if ok {
+							Debugf("Found tile for key %s[%s] of length %d", key, t.tileType, len(tile.data))
+							converted, err := t.convert(tile.coord, tile.data)
+							Debugf("Converted tile for key %s[%s] had length %d", key, t.tileType, len(converted))
+							channel <- batch.TileResponse{
+								Tile: converted,
+								Err:  err,
+							}
+						} else {
+							// No tile, but no error either
+							Debugf("No tile found for key %s", key)
+							defaultTile, err := t.buildDefault()
+							channel <- batch.TileResponse{
+								Tile: defaultTile,
+								Err:  err,
+							}
 						}
 					}
 				}
@@ -289,7 +298,10 @@ func (j *jointRequest) merge(from *jointRequest) {
 // extractJointRequest takes a single batched tile request, and converts it
 // into a joinable consolidated request
 func (t *TileData) extractJointRequest(request *batch.TileRequest) (*jointRequest, error) {
-	t.Parse(request.Params)
+	err := t.Parse(request.Params)
+	if nil != err {
+		return nil, err
+	}
 	tileConfig, err := t.buildConfig()
 	if err != nil {
 		return nil, err

--- a/generation/salt/tile.go
+++ b/generation/salt/tile.go
@@ -181,6 +181,8 @@ func (t *TileData) CreateTiles(requests []*batch.TileRequest) {
 	// Now actually make our requests of the server
 	for _, request := range consolidatedRequests {
 		Infof("Request for %d tiles for dataset %s of type %s", len(request.tiles), request.dataset, t.tileType)
+		// Make sure relevant parameters are available to conversion functions
+		t.Parse(request.params)
 		// Create our consolidated configuration
 		fullConfig := make(map[string]interface{})
 		fullConfig["tile"] = request.tileConfig
@@ -260,6 +262,7 @@ type separateTileRequest struct {
 type jointRequest struct {
 	tileConfig map[string]interface{}
 	query      map[string]interface{}
+	params     map[string]interface{}
 	dataset    string
 	tiles      []*separateTileRequest
 }
@@ -309,7 +312,7 @@ func (t *TileData) extractJointRequest(request *batch.TileRequest) (*jointReques
 	separateRequest := separateTileRequest{request.Coord, request.ResultChannel}
 	separateRequests := []*separateTileRequest{&separateRequest}
 
-	return &jointRequest{tileConfig, queryConfig, request.URI, separateRequests}, nil
+	return &jointRequest{tileConfig, queryConfig, request.Params, request.URI, separateRequests}, nil
 }
 
 // Get a unique string ID for use in maps for a tile coordinate


### PR DESCRIPTION
Still some possiblity of improperly grouped requests having cross-request contamination - all grouped requests get the same parameters (that of the first in the group).
Also, make sure micro tiles pay attention to these parameters when converting