### PR TITLE
Tile Request Updates

### DIFF
--- a/generation/citus/top_terms.go
+++ b/generation/citus/top_terms.go
@@ -18,7 +18,7 @@ func (t *TopTerms) AddAggs(query *Query) *Query {
 	//Assume the backing field is an array. Need to unpack that array and group by the terms.
 	query.Select(fmt.Sprintf("unnest(%s) AS term", t.TermsField))
 
-	query.GroupBy("term")
+	query.GroupBy(t.TermsField)
 	query.Select("COUNT(*) as term_count")
 	query.OrderBy("term_count desc")
 	query.Limit(uint32(t.TermsCount))

--- a/tile/bivariate.go
+++ b/tile/bivariate.go
@@ -80,7 +80,7 @@ func (b *Bivariate) GetXBin(coord *binning.TileCoord, x float64) int {
 }
 
 // GetX given an x value, returns the corresponding coord within the range of
-// [0 : 256) for the tile.
+// [0 : 255) for the tile.
 func (b *Bivariate) GetX(coord *binning.TileCoord, x float64) float64 {
 	bounds := b.TileBounds(coord)
 	rang := bounds.RangeX()


### PR DESCRIPTION
Use width_bucket for the sql query for citus tile requests so that we don't loose any data when we have non-integer sized bins.

Use the "TermsField" for top terms grouping, since there is an option for setting it to a value other than "term".